### PR TITLE
Fix snapshot version dependency

### DIFF
--- a/cnf/build.bnd
+++ b/cnf/build.bnd
@@ -54,4 +54,4 @@ maven-central: true
 		${if;${maven-central};\
 			${.}/releng/central.bnd\
 		}\
-	}	
+	}

--- a/cnf/ext/project.bnd
+++ b/cnf/ext/project.bnd
@@ -21,7 +21,7 @@ Bundle-Developers: \
         organizationUrl="https://www.datainmotion.com"; \
         roles="developer,architect"
 
-project-version: ${base-version}.SNAPSHOT
+project-version: ${base-version}
 mvn-base-version: ${versionmask;===S;${project-version}}
 
 # Includes sources from bundle

--- a/cnf/ext/project.bnd
+++ b/cnf/ext/project.bnd
@@ -21,8 +21,8 @@ Bundle-Developers: \
         organizationUrl="https://www.datainmotion.com"; \
         roles="developer,architect"
 
-project-version: ${base-version}
-mvn-base-version: ${versionmask;===S;${project-version}}
+project-version: ${base-version}.SNAPSHOT
+mvn-base-version: ${versionmask;===S;${Bundle-Version}}
 
 # Includes sources from bundle
 -sources: true

--- a/org.eclipse.fennec.bnd.library/bnd.bnd
+++ b/org.eclipse.fennec.bnd.library/bnd.bnd
@@ -4,7 +4,6 @@
 -includeresource: resources,\
     library/releng=${workspace}/cnf/releng,\
 	{workspace/cnf/central.mvn=resources/workspace/cnf/central.mvn};onduplicate:=OVERWRITE,\
-	{workspace/cnf/central.mvn=resources/workspace/cnf/central.mvn};onduplicate:=OVERWRITE,\
 	{workspace/gradle.properties=resources/workspace/gradle.properties};onduplicate:=OVERWRITE,\
 	{workspace/.gitignore=git/_gitignore}
 

--- a/org.eclipse.fennec.bnd.library/resources/library/workspace.bnd
+++ b/org.eclipse.fennec.bnd.library/resources/library/workspace.bnd
@@ -22,7 +22,7 @@ Bundle-Developers: \
         organizationUrl="https://www.datainmotion.com"; \
         roles="developer,architect"
 
-project-version: ${base-version}.SNAPSHOT
+project-version: ${base-version}
 mvn-base-version: ${versionmask;===s;${project-version}}
 
 # Includes sources from bundle

--- a/org.eclipse.fennec.bnd.library/resources/library/workspace.bnd
+++ b/org.eclipse.fennec.bnd.library/resources/library/workspace.bnd
@@ -22,8 +22,8 @@ Bundle-Developers: \
         organizationUrl="https://www.datainmotion.com"; \
         roles="developer,architect"
 
-project-version: ${base-version}
-mvn-base-version: ${versionmask;===s;${project-version}}
+project-version: ${base-version}.SNAPSHOT
+mvn-base-version: ${versionmask;===S;${Bundle-Version}}
 
 # Includes sources from bundle
 -sources: true

--- a/org.eclipse.fennec.bnd.library/resources/workspace/cnf/central.mvn
+++ b/org.eclipse.fennec.bnd.library/resources/workspace/cnf/central.mvn
@@ -118,8 +118,8 @@ org.slf4j:slf4j-simple:1.7.36
 org.slf4j:slf4j-api:2.0.17
 org.slf4j:slf4j-api:1.7.36
 
-org.eclipse.fennec.bnd:org.eclipse.fennec.bnd.library:${mvn-base-version}
-org.eclipse.fennec.bnd:org.eclipse.fennec.jacoco.bnd.library:${mvn-base-version}
-org.eclipse.fennec.bnd:org.eclipse.fennec.osgitest.bnd.library:${mvn-base-version}
+org.eclipse.fennec.bnd:org.eclipse.fennec.bnd.library:${Bundle-Version}
+org.eclipse.fennec.bnd:org.eclipse.fennec.jacoco.bnd.library:${Bundle-Version}
+org.eclipse.fennec.bnd:org.eclipse.fennec.osgitest.bnd.library:${Bundle-Version}
 
 org.bndtools:org.bndtools.templates.osgi:${bndversion}

--- a/org.eclipse.fennec.osgitest.bnd.library/resources/library/osgi-test.maven
+++ b/org.eclipse.fennec.osgitest.bnd.library/resources/library/osgi-test.maven
@@ -37,4 +37,4 @@ org.objenesis:objenesis:${objenesis.version}
 biz.aQute.bnd:biz.aQute.tester.junit-platform:${bndversion}
 
 # Bring the OSGi test project library and template with this dependency
-org.eclipse.fennec.bnd:org.eclipse.fennec.osgitest.project.bnd.library:${mvn-base-version}
+org.eclipse.fennec.bnd:org.eclipse.fennec.osgitest.project.bnd.library:${Bundle-Version}


### PR DESCRIPTION
The bnd -snapshot: directive in release.bnd/snapshot.bnd only rewrites Bundle-Version; it doesn't touch ${mvn-base-version} macro expansion in resources. Those macros get baked into the JAR at our build time, so they need their own conditional on DO_RELEASE.

The existing release.bnd/snapshot.bnd/central.bnd include flow is unchanged and still drives sonatypeMode (autopublish vs none) via the -snapshot: emptiness check.
