### PR TITLE
docs: fix broken relative link and typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Fennec Bnd Libraries
 
-This project contains **Bndtools Library** definitions..
+This project contains **Bndtools Library** definitions.
 
 You can take a look here about bnd libraries:
 
@@ -33,7 +33,7 @@ This project contains:
 
 ## org.eclipse.fennec.osgitest.project.bnd.library
 
-Please also refer to [OSGi-Test Integration Test Readme](org.elcipse.fennec.osgitest.project.bnd.library/readme.md).
+Please also refer to [OSGi-Test Integration Test Readme](org.eclipse.fennec.osgitest.project.bnd.library/readme.md).
 
 This project contains:
 


### PR DESCRIPTION
The 'OSGi-Test Integration Test Readme' link pointed to org.elcipse.fennec.osgitest.project.bnd.library ('elcipse' typo) and therefore 404'd on GitHub. Also removes a stray double period.

Refs #20

Assisted-by: Anthropic Claude (claude-fable-5)