### PR TITLE
fix: tag the Baseline repository to exclude it from default resolution

### DIFF
--- a/cnf/build.bnd
+++ b/cnf/build.bnd
@@ -54,6 +54,7 @@ maven-central: true
 #		locations	=https://raw.githubusercontent.com/${github-orga}/${github-project}/release-obr/index.xml;\
 #		max.stale	=-1;\
 #		poll.time	=-1;\
+#		tags		=baseline;\
 #		name		=Baseline
 #-baselinerepo: Baseline
 #-baseline: *

--- a/org.eclipse.fennec.bnd.library/resources/library/baseline.bnd
+++ b/org.eclipse.fennec.bnd.library/resources/library/baseline.bnd
@@ -4,11 +4,15 @@
 # workspace build.bnd. The repository location can be overridden by setting
 # 'fennec-baseline-url' there as well ('${def}' is used so the workspace value
 # always wins over this library).
+# The 'baseline' tag (i.e. the absence of the 'resolve' tag) keeps this
+# repository out of the default resolve process, so released versions are
+# never pulled in as dependencies.
 -plugin.baseline: \
 	aQute.bnd.repository.osgi.OSGiRepository;\
 		locations	=${def;fennec-baseline-url;https://raw.githubusercontent.com/${github-orga}/${github-project}/release-obr/index.xml};\
 		max.stale	=-1;\
 		poll.time	=-1;\
+		tags		=baseline;\
 		name		=Baseline
 
 -baselinerepo: Baseline


### PR DESCRIPTION
Adds `tags = baseline` to the `Baseline` OSGiRepository in the `fennec` library's `baseline.bnd`. Untagged repositories are treated like `resolve`-tagged ones during default resolution ([bnd docs](https://bnd.bndtools.org/instructions/runrepos.html)), so workspaces with `fennec-baselining: true` could silently resolve against old released versions from the release OBR. Baselining is unaffected — `-baselinerepo` references the repository by name.

The commented-out baseline plugin in this workspace's own `cnf/build.bnd` gets the same tag so it is correct when enabled.

Verified with `./gradlew build` (successful) and confirmed the built `org.eclipse.fennec.bnd.library.jar` ships the updated `library/baseline.bnd`.

Fixes #21

Note: PR review cannot be requested from the PR author, so the `needs-lead-review` label serves as the review queue entry.

<!-- fennec-agent -->
---
*This was written by an AI agent (Claude Code) operated by a project committer.
A human project lead reviews all agent contributions before merge.*